### PR TITLE
sfneal/view-model-precache merger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,3 +92,8 @@ All notable changes to `view-models` will be documented in this file
 
 ## 1.1.3 - 2021-02-22
 - make PdfViewModel trait for use in ViewModel's that can be used for PDF Exports
+
+
+## 2.0.0 - 2021-03-29
+- make PreCacheViewModel Job for caching ViewModels within the Job queue to provide faster response times
+- add sfneal/queueables to composer requirements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,3 +97,4 @@ All notable changes to `view-models` will be documented in this file
 ## 2.0.0 - 2021-03-29
 - make PreCacheViewModel Job for caching ViewModels within the Job queue to provide faster response times
 - add sfneal/queueables to composer requirements
+- depreciated sfneal/view-model-precache package

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=7.1",
         "sfneal/caching": ">=1.2",
+        "sfneal/queueables": ">=1.0",
         "sfneal/redis-helpers": ">=1.2.1",
         "sfneal/string-helpers": ">=1.0.0",
         "spatie/laravel-view-models": ">=1.1"

--- a/src/PreCacheViewModel.php
+++ b/src/PreCacheViewModel.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Sfneal\ViewModels;
+
+use Sfneal\Queueables\AbstractJob;
+
+class PreCacheViewModel extends AbstractJob
+{
+    /**
+     * @var int Number of seconds to delay dispatching by
+     */
+    public $delay = 30;
+
+    /**
+     * @var string Queue to use
+     */
+    public $queue = 'cache';
+
+    /**
+     * @var AbstractViewModel
+     */
+    private $viewModel;
+
+    /**
+     * @var string
+     */
+    private $route_name;
+
+    /**
+     * @var array
+     */
+    private $route_data;
+
+    /**
+     * PreCacheViewModel constructor.
+     *
+     * @param $viewModel
+     * @param string $route_name
+     * @param array|null $route_data
+     */
+    public function __construct($viewModel, string $route_name, array $route_data = null)
+    {
+        $this->viewModel = $viewModel;
+        $this->route_name = $route_name;
+        $this->route_data = $route_data;
+    }
+
+    /**
+     * Send a GuzzleHttp get request (intended for pre-caching a views).
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        return $this->viewModel
+            ->setRedisKey(route($this->route_name, $this->route_data))
+            ->invalidateCache()
+            ->render();
+    }
+}

--- a/tests/PreCacheViewModelTest.php
+++ b/tests/PreCacheViewModelTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Sfneal\ViewModels\Tests;
+
+use Illuminate\Support\Facades\Queue;
+use Sfneal\ViewModels\AbstractViewModel;
+use Sfneal\ViewModels\PreCacheViewModel;
+use Sfneal\ViewModels\Tests\Mocks\TestViewModel;
+
+class PreCacheViewModelTest extends TestCase
+{
+    /** @var AbstractViewModel */
+    protected $viewModel;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->viewModel = new TestViewModel();
+        $this->viewModel->view('test');
+    }
+
+    public function test_pre_cache()
+    {
+        PreCacheViewModel::dispatchNow($this->viewModel, 'test');
+
+        $this->assertTrue($this->viewModel->isCached());
+        $this->assertIsString($this->viewModel->cacheKey());
+    }
+
+    public function test_pre_cache_queued()
+    {
+        // Enable queue faking
+        Queue::fake();
+
+        // Assert that no jobs were pushed...
+        Queue::assertNothingPushed();
+
+        // Dispatch the first job...
+        Queue::push(new PreCacheViewModel($this->viewModel, 'test'));
+
+        // Assert a job was pushed...
+        Queue::assertPushed(PreCacheViewModel::class, 1);
+    }
+
+    public function test_pre_cache_is_the_same_as_rendered()
+    {
+        $renderNoCache = $this->viewModel->renderNoCache();
+        PreCacheViewModel::dispatchNow($this->viewModel, 'test');
+        $render = $this->viewModel->render();
+
+        $this->assertIsString($renderNoCache);
+        $this->assertIsString($render);
+        $this->assertEquals($renderNoCache, $render);
+    }
+}

--- a/tests/Providers/TestingServiceProvider.php
+++ b/tests/Providers/TestingServiceProvider.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Sfneal\ViewModels\Tests\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class TestingServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        $this->loadRoutesFrom(__DIR__.'/../routes/routes.php');
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -41,7 +41,7 @@ class TestCase extends OrchestraTestCase
             RedisHelpersServiceProvider::class,
             RedisMockServiceProvider::class,
             ViewModelsServiceProvider::class,
-            TestingServiceProvider::class
+            TestingServiceProvider::class,
         ];
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,6 +9,7 @@ use Lunaweb\RedisMock\Providers\RedisMockServiceProvider;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
 use Sfneal\Helpers\Redis\Providers\RedisHelpersServiceProvider;
 use Sfneal\Helpers\Redis\RedisCache;
+use Sfneal\ViewModels\Tests\Providers\TestingServiceProvider;
 use Spatie\ViewModels\Providers\ViewModelsServiceProvider;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -40,6 +41,7 @@ class TestCase extends OrchestraTestCase
             RedisHelpersServiceProvider::class,
             RedisMockServiceProvider::class,
             ViewModelsServiceProvider::class,
+            TestingServiceProvider::class
         ];
     }
 

--- a/tests/routes/routes.php
+++ b/tests/routes/routes.php
@@ -1,0 +1,6 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+
+Route::get('test')->name('test');

--- a/tests/routes/routes.php
+++ b/tests/routes/routes.php
@@ -2,5 +2,4 @@
 
 use Illuminate\Support\Facades\Route;
 
-
 Route::get('test')->name('test');


### PR DESCRIPTION
- make PreCacheViewModel Job for caching ViewModels within the Job queue to provide faster response times
- add sfneal/queueables to composer requirements
- depreciated sfneal/view-model-precache package