### PR TITLE
Add support for sfneal/redis-helpers v2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,3 +119,4 @@ All notable changes to `view-models` will be documented in this file
 
 ## 3.0.2 - 2021-09-01
 - add support for sfneal/redis-helpers v2.0
+- cut use of `RedisCache::remember()` method

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,3 +115,7 @@ All notable changes to `view-models` will be documented in this file
 ## 3.0.1 - 2021-09-01
 - optimize Travis CI config & add code coverage uploading
 - add support for sfneal/caching v2.0
+
+
+## 3.0.2 - 2021-09-01
+- add support for sfneal/redis-helpers v2.0

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=7.1",
         "sfneal/caching": "^1.2|v2.0",
         "sfneal/queueables": "^2.0",
-        "sfneal/redis-helpers": ">=1.2.1",
+        "sfneal/redis-helpers": "^1.2|v2.0",
         "sfneal/string-helpers": ">=1.0.0",
         "spatie/laravel-view-models": ">=1.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     ],
     "require": {
         "php": ">=7.1",
-        "sfneal/caching": "^1.2|v2.0",
+        "sfneal/caching": "^2.0",
         "sfneal/queueables": "^2.0",
-        "sfneal/redis-helpers": "^1.2|v2.0",
+        "sfneal/redis-helpers": "^1.2|^2.0",
         "sfneal/string-helpers": ">=1.0.0",
         "spatie/laravel-view-models": ">=1.1"
     },

--- a/src/ViewModel.php
+++ b/src/ViewModel.php
@@ -3,6 +3,7 @@
 namespace Sfneal\ViewModels;
 
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\View;
 use RuntimeException;
 use Sfneal\Caching\Traits\IsCacheable;
@@ -114,7 +115,7 @@ abstract class ViewModel extends SpatieViewModel
         }
 
         // Cache the View if it doesn't exist
-        return RedisCache::remember($this->cacheKey(), $this->getTTL($ttl), function () {
+        return Cache::remember($this->cacheKey(), $this->getTTL($ttl), function () {
             return $this->__render();
         });
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Sfneal\ViewModels\Tests;
 
 use Illuminate\Foundation\Application;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\View;
 use Lunaweb\RedisMock\Providers\RedisMockServiceProvider;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
@@ -64,7 +65,7 @@ class TestCase extends OrchestraTestCase
      */
     protected function tearDown(): void
     {
-        RedisCache::flush();
+        Cache::flush();
         parent::tearDown();
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,7 +9,6 @@ use Illuminate\Support\Facades\View;
 use Lunaweb\RedisMock\Providers\RedisMockServiceProvider;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
 use Sfneal\Helpers\Redis\Providers\RedisHelpersServiceProvider;
-use Sfneal\Helpers\Redis\RedisCache;
 use Sfneal\ViewModels\Tests\Providers\TestingServiceProvider;
 use Spatie\ViewModels\Providers\ViewModelsServiceProvider;
 use Symfony\Component\HttpFoundation\Response;


### PR DESCRIPTION
- add support for sfneal/redis-helpers v2.0
- cut use of `RedisCache::remember()` method