### PR TITLE
Conditional disable ViewModel caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docs
 vendor
 coverage
 .idea
+.phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 docs
 vendor
 coverage
+.idea

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml
-# Editor-based HTTP Client requests
-/httpRequests/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,3 +120,9 @@ All notable changes to `view-models` will be documented in this file
 ## 3.0.2 - 2021-09-01
 - add support for sfneal/redis-helpers v2.0
 - cut use of `RedisCache::remember()` method
+
+
+## 3.1.0 - 2021-09-24
+- make `CachingPreferences` trait that's used by `ViewModel` for conditionally disabling caching in different app environments
+- add `dontCacheInDevelopment()`, `dontCacheInProduction()` & `dontCacheIf()` methods to `CachingPreferences` & `ViewModel`
+- add sfneal/laravel-helpers composer requirement for checking app env

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": ">=7.1",
         "sfneal/caching": "^2.0",
+        "sfneal/laravel-helpers": "^2.4",
         "sfneal/queueables": "^2.0",
         "sfneal/redis-helpers": "^1.2|^2.0",
         "sfneal/string-helpers": ">=1.0.0",

--- a/src/PreCacheViewModel.php
+++ b/src/PreCacheViewModel.php
@@ -35,8 +35,8 @@ class PreCacheViewModel extends Job
      * PreCacheViewModel constructor.
      *
      * @param $viewModel
-     * @param string $route_name
-     * @param array|null $route_data
+     * @param  string  $route_name
+     * @param  array|null  $route_data
      */
     public function __construct($viewModel, string $route_name, array $route_data = null)
     {

--- a/src/Traits/CachingPreferences.php
+++ b/src/Traits/CachingPreferences.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Sfneal\ViewModels\Traits;
+
+use Sfneal\Helpers\Laravel\AppInfo;
+
+trait CachingPreferences
+{
+    /**
+     * @var bool Determine if caching has been disabled.
+     */
+    protected $cachingDisabled = false;
+
+    /**
+     * Disable ViewModel render caching if the conditional evaluates as true.
+     *
+     * @param bool $conditional
+     * @return $this
+     */
+    public function dontCacheIf(bool $conditional): self
+    {
+        if ($conditional) {
+            $this->cachingDisabled = true;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Disable ViewModel render caching if the app environment is 'development'.
+     *
+     * @return $this
+     */
+    public function dontCacheInDevelopment(): self
+    {
+        if (AppInfo::isEnvDevelopment()) {
+            $this->cachingDisabled = true;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Disable ViewModel render caching if the app environment is 'production'.
+     *
+     * @return $this
+     */
+    public function dontCacheInProduction(): self
+    {
+        if (AppInfo::isEnvProduction()) {
+            $this->cachingDisabled = true;
+        }
+
+        return $this;
+    }
+}

--- a/src/Traits/CachingPreferences.php
+++ b/src/Traits/CachingPreferences.php
@@ -14,7 +14,7 @@ trait CachingPreferences
     /**
      * Disable ViewModel render caching if the conditional evaluates as true.
      *
-     * @param bool $conditional
+     * @param  bool  $conditional
      * @return $this
      */
     public function dontCacheIf(bool $conditional): self

--- a/src/Traits/DateSetter.php
+++ b/src/Traits/DateSetter.php
@@ -9,9 +9,9 @@ trait DateSetter
     /**
      * Set a search value for $start or $end property.
      *
-     * @param Request $request
-     * @param string $key
-     * @param string $time
+     * @param  Request  $request
+     * @param  string  $key
+     * @param  string  $time
      * @return string
      */
     private function setDay(Request $request, string $key, string $time = '00:00:00'): ?string
@@ -26,8 +26,8 @@ trait DateSetter
     /**
      * Retrieve the datetime for a date at midnight.
      *
-     * @param string $date
-     * @param string $time
+     * @param  string  $date
+     * @param  string  $time
      * @return string
      */
     private static function getDatetime(string $date, string $time = '00:00:00'): string

--- a/src/Traits/FormStatus.php
+++ b/src/Traits/FormStatus.php
@@ -31,7 +31,7 @@ trait FormStatus
     /**
      * Set a Client Inquiry success/failure status to be displayed in the view model.
      *
-     * @param string $status
+     * @param  string  $status
      * @return $this
      */
     private function withStatus(string $status): self

--- a/src/Traits/PdfViewModel.php
+++ b/src/Traits/PdfViewModel.php
@@ -12,7 +12,7 @@ trait PdfViewModel
     /**
      * Declare this ViewModel is being used to create a PDF.
      *
-     * @param bool $value
+     * @param  bool  $value
      * @return $this
      */
     public function forPdfOutput(bool $value = true): self

--- a/src/ViewModel.php
+++ b/src/ViewModel.php
@@ -77,6 +77,7 @@ abstract class ViewModel extends SpatieViewModel
      * Retrieve a unique redis key for caching the view.
      *
      * // todo: add property?
+     *
      * @return string
      */
     public function cacheKey(): string
@@ -92,7 +93,7 @@ abstract class ViewModel extends SpatieViewModel
      *
      * // todo: refactor this
      *
-     * @param string $redis_key
+     * @param  string  $redis_key
      * @return $this
      */
     public function setRedisKey(string $redis_key): self
@@ -105,8 +106,8 @@ abstract class ViewModel extends SpatieViewModel
     /**
      * Retrieve/render the ViewModel from/to the application cache.
      *
-     * @param string|null $view
-     * @param int|null $ttl
+     * @param  string|null  $view
+     * @param  int|null  $ttl
      * @return string
      */
     public function render(string $view = null, int $ttl = null): string
@@ -130,7 +131,7 @@ abstract class ViewModel extends SpatieViewModel
     /**
      * Render the ViewModel without storing or retrieving from the Cache.
      *
-     * @param string|null $view
+     * @param  string|null  $view
      * @return Response|string|mixed
      */
     public function renderNoCache(string $view = null)
@@ -146,7 +147,7 @@ abstract class ViewModel extends SpatieViewModel
     /**
      * Invalidate the View Cache for this ViewModel.
      *
-     * @param bool $children
+     * @param  bool  $children
      * @return $this
      */
     public function invalidateCache($children = true): self
@@ -159,7 +160,7 @@ abstract class ViewModel extends SpatieViewModel
     /**
      * Return a concatenated route or view name by using the PREFIX const.
      *
-     * @param string $string
+     * @param  string  $string
      * @return $this
      */
     public function viewWithPrefix(string $string): self
@@ -172,7 +173,7 @@ abstract class ViewModel extends SpatieViewModel
     /**
      * Extend a view name.
      *
-     * @param string $string
+     * @param  string  $string
      * @return $this
      */
     public function viewExtend(string $string): self
@@ -188,7 +189,7 @@ abstract class ViewModel extends SpatieViewModel
      *  - 2. initialized $this->ttl property
      *  - 3. application default cache ttl.
      *
-     * @param int|null $ttl
+     * @param  int|null  $ttl
      * @return int
      */
     public function getTTL(int $ttl = null): int
@@ -199,7 +200,7 @@ abstract class ViewModel extends SpatieViewModel
     /**
      * Set the $ttl property during runtime.
      *
-     * @param int $ttl
+     * @param  int  $ttl
      * @return $this
      */
     public function setTTL(int $ttl): self

--- a/src/ViewModel.php
+++ b/src/ViewModel.php
@@ -9,11 +9,13 @@ use RuntimeException;
 use Sfneal\Caching\Traits\IsCacheable;
 use Sfneal\Helpers\Redis\RedisCache;
 use Sfneal\Helpers\Strings\StringHelpers;
+use Sfneal\ViewModels\Traits\CachingPreferences;
 use Spatie\ViewModels\ViewModel as SpatieViewModel;
 
 abstract class ViewModel extends SpatieViewModel
 {
     // todo: make more properties private and add getters/setters
+    use CachingPreferences;
     use IsCacheable;
 
     /**
@@ -109,6 +111,11 @@ abstract class ViewModel extends SpatieViewModel
      */
     public function render(string $view = null, int $ttl = null): string
     {
+        // Don't cache if caching has been disabled
+        if ($this->cachingDisabled) {
+            return $this->renderNoCache($view);
+        }
+
         // Set $view if it is not null
         if ($view) {
             $this->view = $view;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,6 +23,8 @@ class TestCase extends OrchestraTestCase
      */
     protected function getEnvironmentSetUp($app)
     {
+        parent::getEnvironmentSetUp($app);
+
         $app['config']->set('app.debug', true);
         $app['config']->set('database.redis.client', 'mock');
         $app['config']->set('cache.default', 'redis');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -18,7 +18,7 @@ class TestCase extends OrchestraTestCase
     /**
      * Define environment setup.
      *
-     * @param Application $app
+     * @param  Application  $app
      * @return void
      */
     protected function getEnvironmentSetUp($app)
@@ -34,7 +34,7 @@ class TestCase extends OrchestraTestCase
     /**
      * Register package service providers.
      *
-     * @param Application $app
+     * @param  Application  $app
      * @return array|string
      */
     protected function getPackageProviders($app)

--- a/tests/ViewModelCachingPreferencesTest.php
+++ b/tests/ViewModelCachingPreferencesTest.php
@@ -14,7 +14,7 @@ class ViewModelCachingPreferencesTest extends TestCase
     /**
      * Define environment setup.
      *
-     * @param Application $app
+     * @param  Application  $app
      * @return void
      */
     protected function getEnvironmentSetUp($app)

--- a/tests/ViewModelCachingPreferencesTest.php
+++ b/tests/ViewModelCachingPreferencesTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Sfneal\ViewModels\Tests;
+
+use Illuminate\Foundation\Application;
+use Sfneal\ViewModels\Tests\Mocks\TestViewModel;
+use Sfneal\ViewModels\ViewModel;
+
+class ViewModelCachingPreferencesTest extends TestCase
+{
+    /** @var ViewModel */
+    protected $viewModel;
+
+    /**
+     * Define environment setup.
+     *
+     * @param Application $app
+     * @return void
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('app.env', 'development');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->viewModel = new TestViewModel();
+        $this->viewModel->view('test');
+    }
+
+    public function test_caching_is_disabled_in_development()
+    {
+        // Disable caching in dev
+        $this->viewModel->dontCacheInDevelopment();
+
+        $this->viewModel->render();
+
+        $this->assertFalse($this->viewModel->isCached());
+    }
+
+    public function test_caching_is_disabled_by_conditional()
+    {
+        // Disable caching in dev
+        $this->viewModel->dontCacheIf(true);
+
+        $this->viewModel->render();
+
+        $this->assertFalse($this->viewModel->isCached());
+    }
+
+    public function test_caching_is_not_disabled_by_conditional()
+    {
+        // Disable caching in dev
+        $this->viewModel->dontCacheIf(false);
+
+        $this->viewModel->render();
+
+        $this->assertTrue($this->viewModel->isCached());
+    }
+}


### PR DESCRIPTION
- make `CachingPreferences` trait that's used by `ViewModel` for conditionally disabling caching in different app environments
- add `dontCacheInDevelopment()`, `dontCacheInProduction()` & `dontCacheIf()` methods to `CachingPreferences` & `ViewModel`
- add sfneal/laravel-helpers composer requirement for checking app env