### PR TITLE
Exclude Style CI Branches from GitHub Workflows

### DIFF
--- a/.github/workflows/composer.yml
+++ b/.github/workflows/composer.yml
@@ -2,7 +2,11 @@ name: Composer
 
 on:
     push:
+        branches-ignore:
+            - 'analysis-*'
     pull_request:
+        branches-ignore:
+            - 'analysis-*'
 
 jobs:
     build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,11 @@ name: Test Suite
 
 on:
     push:
+        branches-ignore:
+            - 'analysis-*'
     pull_request:
+        branches-ignore:
+            - 'analysis-*'
     release:
         types: [published]
 


### PR DESCRIPTION
- add ignoring 'analysis-*' (Style CI) branches from having actions run on them