### PR TITLE
Add `dontCacheInLocal()` & `onlyCacheInProduction()` methods to `CachingPreferences` trait

### DIFF
--- a/src/Traits/CachingPreferences.php
+++ b/src/Traits/CachingPreferences.php
@@ -53,4 +53,42 @@ trait CachingPreferences
 
         return $this;
     }
+
+    /**
+     * Disable ViewModel render caching if the app environment is 'local'.
+     *
+     * @return $this
+     */
+    public function dontCacheInLocal(): self
+    {
+        return $this->dontCacheInEnv('local');
+    }
+
+    /**
+     * Disable ViewModel render caching if the app environment is 'local'.
+     *
+     * @return $this
+     */
+    public function dontCacheInEnv(string $env): self
+    {
+        if (AppInfo::isEnv($env)) {
+            $this->cachingDisabled = true;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Disable caching if the environment is not 'production'
+     *
+     * @return $this
+     */
+    public function onlyCacheInProduction(): self
+    {
+        if (! AppInfo::isEnvProduction()) {
+            $this->cachingDisabled = true;
+        }
+
+        return $this;
+    }
 }

--- a/src/Traits/CachingPreferences.php
+++ b/src/Traits/CachingPreferences.php
@@ -79,7 +79,7 @@ trait CachingPreferences
     }
 
     /**
-     * Disable caching if the environment is not 'production'
+     * Disable caching if the environment is not 'production'.
      *
      * @return $this
      */


### PR DESCRIPTION
- add methods for deterministically caching view models based on local or production app environments
- allows view model caching to be disabled in local environments
- allows view model caching to only be enabled in production environments 